### PR TITLE
confection 0.1.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+aggregate_branch: 3.12
+
+channels:
+    - https://staging.continuum.io/prefect/fs/srsly-feedstock/pr8/c993ad1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  # for srsly 2.4.8:
-  - https://staging.continuum.io/prefect/fs/srsly-feedstock/pr8/ce69f6c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,5 @@
 aggregate_branch: 3.12
 
 channels:
-    - https://staging.continuum.io/prefect/fs/srsly-feedstock/pr8/c993ad1
+  # for srsly 2.4.8:
+  - https://staging.continuum.io/prefect/fs/srsly-feedstock/pr8/ce69f6c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "confection" %}
-{% set version = "0.0.4" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b1ddf5885da635f0e260a40b339730806dfb1bd17d30e08764f35af841b04ecf
+  sha256: e80f22fd008b5231a2e8852fac6de9e28f2276a04031d0536cff74fe4a990c8f
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.11.0
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,<3.0.0
     - typing_extensions >=3.7.4.1,<4.5.0  # [py<38]
     - srsly >=2.4.0,<3.0.0
 
@@ -30,9 +30,12 @@ test:
   imports:
     - {{ name }}
   requires:
+    - catalogue >=2.0.3,<2.1.0
     - pytest >=5.2.0,!=7.1.0
     - numpy
+    - pip
   commands:
+    - pip check
     - python -m pytest --tb=native --pyargs {{ name }}
 
 about:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3712](https://anaconda.atlassian.net/browse/PKG-3712) 
- [Upstream repository]()
- Requirements:
- https://github.com/explosion/confection/blob/v0.1.4/pyproject.toml
- https://github.com/explosion/confection/blob/v0.1.4/requirements.txt
- https://github.com/explosion/confection/blob/v0.1.4/setup.cfg
- https://github.com/explosion/confection/blob/v0.1.4/setup.py

### Explanation of changes:

- Update  the`pydantic`'s upper bound in `run`
- Add `catalogue >=2.0.3,<2.1.0` to `test/requires`
- Add pip check

### Notes:

- `thinc` requires it  https://github.com/AnacondaRecipes/thinc-feedstock/pull/15

[PKG-3712]: https://anaconda.atlassian.net/browse/PKG-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ